### PR TITLE
Bump up body font size

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,7 +26,6 @@
     background-color: #EFE6E6;
     color: #FFF;
     font-family: "Helvetica Neue",Helvetica,Arial,"Nimbus Sans L",sans-serif;
-    font-size: 90%;
     margin: 0px;
 }
 
@@ -54,5 +53,3 @@
     font-size: 13px;
     line-height: 18px;
 }
-
-


### PR DESCRIPTION
There was a font-size property on the body that made the text
minuscule. This commit just removes it so the text is legible.